### PR TITLE
feat(AccountManagement): add account_discord template variable to general information

### DIFF
--- a/account.management.html.twig
+++ b/account.management.html.twig
@@ -171,6 +171,10 @@
 												<td class="LabelV" >Registered:</td>
 												<td>{{ account_registered }}</td>
 											</tr>
+											<tr style="background-color: {{ config.lightborder }};" >
+												<td class="LabelV" >Linked Discord Account:</td>
+												<td>{{ account_discord }}</td>
+											</tr>
 											{% endautoescape %}
 										</table>
 									</div>


### PR DESCRIPTION
Related to https://github.com/Hydractify/myaac/pull/1.

Adds a new entry to the general information list so users can add, see, and remove their (linked) Discord account.